### PR TITLE
fix: 호이고사 일정 시간 매칭 수정

### DIFF
--- a/src/lib/hoi4-exam-binding.ts
+++ b/src/lib/hoi4-exam-binding.ts
@@ -5,6 +5,7 @@ import {
   formatKstTimeLabel,
   isValidDate,
   kstDateKey,
+  toValidDate,
 } from '@/lib/hoi4-exam-time';
 
 export type Hoi4GermanExamBinding = {
@@ -18,6 +19,10 @@ export type Hoi4GermanExamBinding = {
 
 function hasValidStartTime(schedule: FlattenedSchedule): boolean {
   return isValidDate(schedule.startTime);
+}
+
+function getScheduleStart(schedule: FlattenedSchedule): Date | null {
+  return toValidDate(schedule.startTime);
 }
 
 function matchesExamScheduleTitle(
@@ -44,7 +49,9 @@ function pickTodaySchedule(
   if (atSeven) return atSeven;
 
   return todayMatches.sort(
-    (a, b) => a.startTime.getTime() - b.startTime.getTime(),
+    (a, b) =>
+      (getScheduleStart(a)?.getTime() ?? Infinity) -
+      (getScheduleStart(b)?.getTime() ?? Infinity),
   )[0];
 }
 
@@ -78,20 +85,30 @@ export function resolveHoi4GermanExamBinding(
   }
 
   const upcoming = pool
-    .filter((schedule) => schedule.startTime.getTime() > now.getTime())
-    .sort((a, b) => a.startTime.getTime() - b.startTime.getTime());
+    .filter((schedule) => {
+      const start = getScheduleStart(schedule);
+      return start ? start.getTime() > now.getTime() : false;
+    })
+    .sort(
+      (a, b) =>
+        (getScheduleStart(a)?.getTime() ?? Infinity) -
+        (getScheduleStart(b)?.getTime() ?? Infinity),
+    );
   if (upcoming.length > 0) {
     return toBinding(upcoming[0]);
   }
 
   const latestPast = pool.sort(
-    (a, b) => b.startTime.getTime() - a.startTime.getTime(),
+    (a, b) =>
+      (getScheduleStart(b)?.getTime() ?? -Infinity) -
+      (getScheduleStart(a)?.getTime() ?? -Infinity),
   )[0];
   return toBinding(latestPast);
 }
 
 function toBinding(schedule: FlattenedSchedule): Hoi4GermanExamBinding {
-  if (!hasValidStartTime(schedule)) {
+  const scheduledStart = getScheduleStart(schedule);
+  if (!scheduledStart) {
     return {
       schedule: null,
       examId: null,
@@ -104,7 +121,7 @@ function toBinding(schedule: FlattenedSchedule): Hoi4GermanExamBinding {
     schedule,
     examId: schedule.id,
     legacyExamId: kstDateKey(schedule.startTime),
-    scheduledStart: schedule.startTime,
+    scheduledStart,
   };
 }
 

--- a/src/lib/hoi4-exam-time.ts
+++ b/src/lib/hoi4-exam-time.ts
@@ -1,40 +1,51 @@
 /** KST datetime-local ↔ ISO 변환·표시 */
 
-export function isValidDate(date: Date): boolean {
-  return date instanceof Date && Number.isFinite(date.getTime());
+export type DateLike = Date | string | number | null | undefined;
+
+export function toValidDate(date: DateLike): Date | null {
+  if (date == null) return null;
+  const resolved = date instanceof Date ? date : new Date(date);
+  return Number.isFinite(resolved.getTime()) ? resolved : null;
 }
 
-export function kstDateKey(date: Date): string {
-  if (!isValidDate(date)) return '';
+export function isValidDate(date: DateLike): boolean {
+  return toValidDate(date) !== null;
+}
+
+export function kstDateKey(date: DateLike): string {
+  const resolved = toValidDate(date);
+  if (!resolved) return '';
   return new Intl.DateTimeFormat('en-CA', {
     timeZone: 'Asia/Seoul',
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
-  }).format(date);
+  }).format(resolved);
 }
 
-export function formatKstTimeLabel(date: Date): string {
-  if (!isValidDate(date)) return '—';
+export function formatKstTimeLabel(date: DateLike): string {
+  const resolved = toValidDate(date);
+  if (!resolved) return '—';
   const parts = new Intl.DateTimeFormat('en-GB', {
     timeZone: 'Asia/Seoul',
     hour: '2-digit',
     minute: '2-digit',
     hour12: false,
-  }).formatToParts(date);
+  }).formatToParts(resolved);
   const hour = parts.find((part) => part.type === 'hour')?.value ?? '00';
   const minute = parts.find((part) => part.type === 'minute')?.value ?? '00';
   return `${hour}:${minute}`;
 }
 
-export function formatKstDateLabel(date: Date): string {
-  if (!isValidDate(date)) return '—';
+export function formatKstDateLabel(date: DateLike): string {
+  const resolved = toValidDate(date);
+  if (!resolved) return '—';
   return new Intl.DateTimeFormat('ko-KR', {
     timeZone: 'Asia/Seoul',
     month: 'numeric',
     day: 'numeric',
     weekday: 'short',
-  }).format(date);
+  }).format(resolved);
 }
 
 export function formatKstDateTime(iso: string): string {

--- a/src/lib/hoi4GermanExam.ts
+++ b/src/lib/hoi4GermanExam.ts
@@ -2,7 +2,6 @@ import { format, differenceInCalendarDays, startOfDay } from 'date-fns';
 import { ko } from 'date-fns/locale';
 import type { Hoi4GermanExamConfig, Hoi4GermanExamEntry } from '@/config/hoi4GermanExam2026';
 import type { Hoi4GermanExamBinding } from '@/lib/hoi4-exam-binding';
-import { resolveHoi4GermanExamBinding } from '@/lib/hoi4-exam-binding';
 import type { Hoi4ExamRuntimeState } from '@/lib/hoi4-exam-state';
 import { formatKstDateLabel, formatKstTimeLabel } from '@/lib/hoi4-exam-time';
 import type { FlattenedSchedule } from '@/lib/schedule-formatters';
@@ -444,9 +443,14 @@ export function patchModelWithRuntimeState(
   runtime: Hoi4ExamRuntimeState,
   now = new Date(),
 ): Hoi4GermanExamViewModel {
-  const scheduledStart = model.scheduledStartAt
-    ? new Date(model.scheduledStartAt)
-    : new Date();
+  if (!model.scheduledStartAt) {
+    return {
+      ...model,
+      manualStartedAt: runtime.manualStartedAt,
+    };
+  }
+
+  const scheduledStart = new Date(model.scheduledStartAt);
   const manualStartedAt = runtime.manualStartedAt
     ? new Date(runtime.manualStartedAt)
     : null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 요약
- 호이고사 일정 매칭에서 캐시 복원된 문자열 시간을 Date로 정규화
- 일정이 없을 때 클라이언트 보정이 READY 상태를 만들지 않도록 수정
- 호이고사 모델 파일의 미사용 import 정리

## 검증
- `npx eslint "src/lib/hoi4-exam-time.ts" "src/lib/hoi4-exam-binding.ts" "src/lib/hoi4GermanExam.ts"`
- `DATABASE_URL="postgresql://user:pass@localhost:5432/db" npx prisma generate && npx tsc --noEmit --pretty false`
- `DATABASE_URL="postgresql://user:pass@localhost:5432/db" MAP_DYOA_SERVER_URL="https://www.map-doya.site/map-dyoa-api" NEXT_PUBLIC_SITE_URL="https://www.map-doya.site" npm run build`
- 로컬 빌드 서버에서 `/lab/time-attack` 응답 확인: `참가 11명`, 일정 ID `r1x7jak36bqn46kq9ah3pze1`

## 참고
- 전체 `npm run lint`는 기존 파일들의 React Hooks 규칙 및 스크립트 import 오류로 실패함
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6e06fe6-e587-41f3-98b4-c32202d35899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6e06fe6-e587-41f3-98b4-c32202d35899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

